### PR TITLE
Time.new was removed in 0.33.0, needs to be Time.local now

### DIFF
--- a/src/circuit_breaker.cr
+++ b/src/circuit_breaker.cr
@@ -22,7 +22,7 @@ class CircuitBreaker
   # ```
   def initialize(threshold @error_threshold, timewindow timeframe, reenable_after @duration, handled_errors = [] of Exception, ignored_errors = [] of Exception)
     @state = CircuitState.new
-    @reclose_time = Time.new
+    @reclose_time = Time.local
     @error_watcher = ErrorWatcher.new(Time::Span.new(0, 0, timeframe))
 
     # two-step initialization because of known crystal compiler bug
@@ -105,13 +105,13 @@ class CircuitBreaker
   private def trip
     @state.trip
 
-    @reclose_time = Time.new + Time::Span.new(0, 0, @duration)
+    @reclose_time = Time.local + Time::Span.new(0, 0, @duration)
   end
 
   private def reset
     @state.reset
 
-    @reclose_time = Time.new
+    @reclose_time = Time.local
     @error_watcher.reset
   end
 
@@ -120,7 +120,7 @@ class CircuitBreaker
   end
 
   private def reclose?
-    if Time.new > @reclose_time
+    if Time.local > @reclose_time
       @state.attempt_reset
       true
     else
@@ -130,7 +130,7 @@ class CircuitBreaker
 
   private def open_circuit
     @state.trip
-    @reclose_time = Time.new + Time::Span.new(0, 0, @duration)
+    @reclose_time = Time.local + Time::Span.new(0, 0, @duration)
   end
 end
 

--- a/src/error_watcher.cr
+++ b/src/error_watcher.cr
@@ -7,11 +7,11 @@ class ErrorWatcher
   end
 
   def add_failure
-    @failures << Time.new
+    @failures << Time.local
   end
 
   def add_execution
-    @executions << Time.new
+    @executions << Time.local
   end
 
   def reset
@@ -37,7 +37,7 @@ class ErrorWatcher
   end
 
   private def clean_old(arr : Array(Time))
-    threshold = Time.new - @timeframe
+    threshold = Time.local - @timeframe
 
     arr.reject! { |time| time < threshold }
   end


### PR DESCRIPTION
been deprecated since 0.28.0 or so... *whoopsie*

Adds support for 0.33.0