### PR TITLE
Fix breaking change to Time::Span.new in 0.34.0

### DIFF
--- a/spec/error_watcher_spec.cr
+++ b/spec/error_watcher_spec.cr
@@ -9,7 +9,7 @@ describe "ErrorWatcher" do
 
   describe "#error_rate" do
     it "calculates error rate correctly and cleans after time" do
-      watcher = ErrorWatcher.new(Time::Span.new(0, 0, 1))
+      watcher = ErrorWatcher.new(Time::Span.new(hours: 0, minutes: 0, seconds: 1))
       watcher.add_failure
       watcher.add_execution
       watcher.error_rate.should eq 100
@@ -18,7 +18,7 @@ describe "ErrorWatcher" do
     end
 
     it "throws an error if there are more failures than executions" do
-      watcher = ErrorWatcher.new(Time::Span.new(0, 0, 60))
+      watcher = ErrorWatcher.new(Time::Span.new(hours: 0, minutes: 0, seconds: 60))
       watcher.add_failure
       expect_raises MoreErrorsThanExecutionsException do
         watcher.error_rate
@@ -26,7 +26,7 @@ describe "ErrorWatcher" do
     end
 
     it "returns 0 if failures and executions are empty" do
-      watcher = ErrorWatcher.new(Time::Span.new(0, 0, 60))
+      watcher = ErrorWatcher.new(Time::Span.new(hours: 0, minutes: 0, seconds: 60))
       watcher.error_rate.should eq 0
     end
   end

--- a/src/circuit_breaker.cr
+++ b/src/circuit_breaker.cr
@@ -23,7 +23,7 @@ class CircuitBreaker
   def initialize(threshold @error_threshold, timewindow timeframe, reenable_after @duration, handled_errors = [] of Exception, ignored_errors = [] of Exception)
     @state = CircuitState.new
     @reclose_time = Time.local
-    @error_watcher = ErrorWatcher.new(Time::Span.new(0, 0, timeframe))
+    @error_watcher = ErrorWatcher.new(Time::Span.new(hours: 0, minutes: 0, seconds: timeframe))
 
     # two-step initialization because of known crystal compiler bug
     @handled_errors = [] of Exception
@@ -105,7 +105,7 @@ class CircuitBreaker
   private def trip
     @state.trip
 
-    @reclose_time = Time.local + Time::Span.new(0, 0, @duration)
+    @reclose_time = Time.local + Time::Span.new(hours: 0, minutes: 0, seconds: @duration)
   end
 
   private def reset
@@ -130,7 +130,7 @@ class CircuitBreaker
 
   private def open_circuit
     @state.trip
-    @reclose_time = Time.local + Time::Span.new(0, 0, @duration)
+    @reclose_time = Time.local + Time::Span.new(hours: 0, minutes: 0, seconds: @duration)
   end
 end
 


### PR DESCRIPTION
Since 0.34.0, the three-argument constructor has been removed and named arguments are now required.